### PR TITLE
README: Fix typo in name of project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Placebalue Ascii
+# Placevalue Ascii
 
 Creates an ascii representation of the binary ouput of two variable function at a certian place value, arrayed on a grid.
 


### PR DESCRIPTION
The README told me that the name of this project is `Placebalue`. I don’t think that’s correct, so I fixed it.

Cheers